### PR TITLE
Feature/#22  allow template customisation hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,34 @@ As part of the callback *mapsed* typically passes the data for the place the eve
   <tr><td>url</td><td>More info url</td></tr>
 </table>
 
+## Template Customisations
+
+Allows custom text/html to be injected as a header and/or footer to the tooltip window which 
+appears when the end-user selects or adds a new _place_.
+
+````js
+templateOptions: {
+  custom: {
+    view: {
+      header: "<center>custom view header</center>",
+      footer: "<center>custom view footer</center>",
+    },
+    edit: {
+      header: "<center>custom edit header</center>",
+      footer: "<center>custom edit footer</center>"
+    }
+  }
+}
+````
+
+The above customisation will show a header and footer to the map tooltip when and end-user selects a _custom_ place.
+
+Custom headers & footers can be set for:
+ - _Custom_ places as above
+ - _New_ places (when your end-user clicks the [+](#onAdd) button
+ - _Google_ places where a map _marker_ is derived from [Google Places API](#Google-Place)
+
+[See full-window example](examples/06-full-example.js)
 
 ## Events / Callbacks
 

--- a/examples/02-place-picker-example.js
+++ b/examples/02-place-picker-example.js
@@ -30,9 +30,16 @@ function runExample2() {
 				lat: 53.798823,
 				lng:-1.5426760000000286,
 				place_id: "ChIJQd3IwBtceUgRha6laiANoro"
+			},
+		templateOptions: {
+			google: {
+				view: {
+					footer: "<center>I came from Google Places</center>",
+				}
 			}
-		
-	});
+		}
+
+	}); // mapsed
 }
 
 $(document).ready(function() {

--- a/examples/06-full-example.js
+++ b/examples/06-full-example.js
@@ -178,7 +178,50 @@ function fullWindowExample(e) {
 			// indicate tip should be closed
 			return true;
 		},
-		
+
+		// Defines header and footers to be applied to the 
+		// ... select/edit/delete tooltips shown to the user
+		templateOptions: {
+			// You can have a different header or footer for
+			// each "markerType".  Supported customisations are:
+			// "custom" - Where your user has previously added a marker
+			// "add" - Where your user has click "add" to create a new marker
+			// "google" - Where your user has clicked on a marker found via Google Places APi
+			custom: {
+				view: {
+					header: "<center>custom view header</center>",
+					footer: "<center>custom view footer</center>",
+				},
+				edit: {
+					header: "<center>custom edit header</center>",
+					footer: "<center>custom edit footer</center>"
+				}
+			},
+
+			add: {
+				view: {
+					header: "<center>add view header</center>",
+					footer: "<center>add view footer</center>",
+				},
+				edit: {
+					header: "<center>add edit header</center>",
+					footer: "<center>add edit footer</center>"
+				}
+			},
+
+			google: {
+				view: {
+					header: "<center>google view header</center>",
+					footer: "<center>google view footer</center>",
+				},
+				edit: {
+					header: "<center>google edit header</center>",
+					footer: "<center>google edit footer</center>"
+				}
+			}
+
+		},
+
 		// Enables edit of new places (to your web application, not Google Maps!)
 		// ... again the presence of the callback enables the functionality
 		onSave: function(m, newPlace) {

--- a/index.html
+++ b/index.html
@@ -187,14 +187,22 @@ $("#place-picker").mapsed({
   },
   
   showOnLoad: 
-    // City Varieties - note there's only one place here, we don't need an array
-    {
-      // flag that this place should have the tooltip shown when the map is first loaded
-      autoShow: true,
-      lat: 53.798823,
-      lng:-1.5426760000000286,
-      place_id: "ChIJQd3IwBtceUgRha6laiANoro"
+  // City Varieties
+  {
+    // flag that this place should have the tooltip shown when the map is first loaded
+    autoShow: true,
+    lat: 53.798823,
+    lng:-1.5426760000000286,
+    place_id: "ChIJQd3IwBtceUgRha6laiANoro"
+  },
+  templateOptions: {
+    google: {
+      view: {
+        footer: '&lt;center&gt;I came from Google Places&lt;/center&gt;',
+      }
     }
+  }
+
 });
 								</pre>
 							</div>
@@ -202,6 +210,9 @@ $("#place-picker").mapsed({
 								The <em>Select</em> button is turned on simply by implementing 
 								the <a href="https://github.com/toepoke/mapsed/blob/master/README.md#onselect">onSelect</a> 
 								callback.
+							</p>
+							<p>
+								Note you can also add your own <a href="https://github.com/toepoke/mapsed/blob/master/README.md#Template-Customisations">headers &amp; footers</a> too.
 							</p>
 						</div>
 					</div>


### PR DESCRIPTION
Added notion of "templateOptions" that allow the user to define headers and footers for each type of "marker".  Rational being that they may wish to convey a different message for each type, or only have a header/footer for one type of "marker".

The lack of a "templateOption" for a given type of "marker" means it's not used, giving us some nice flexibility.

Close https://github.com/toepoke/mapsed/issues/20