### PR TITLE
fix(#25): Saving a "new" marker doesn't change the marker icon.

### DIFF
--- a/mapsed.js
+++ b/mapsed.js
@@ -596,6 +596,14 @@
 
 			// update the model to reflect the changes made
 			jQuery.extend(marker.details, place);
+			// ... markerType is held a two levels
+			marker.markerType = place.markerType;
+
+			// update the icon (place could be new and then been saved)
+			if (settings.getMarkerImage) {
+				var image = settings.getMarkerImage(_plugIn, marker.markerType);
+				marker.setIcon(image.url);
+			}
 
 			// once an object has been edited successfully it becomes a normal editable "custom" object
 			root.find(".mapsed-marker-type").val("custom");


### PR DESCRIPTION
We weren't updating the icon once the status of the marker had changed.

Closes #25 